### PR TITLE
 让 Overlay 支持在蒙层下方内容滚动时自动关闭

### DIFF
--- a/components/Menu/Menu.js
+++ b/components/Menu/Menu.js
@@ -18,8 +18,9 @@ export default class Menu extends Overlay {
   //   icon: PropTypes.oneOfType([PropTypes.element, PropTypes.shape({uri: PropTypes.string}), PropTypes.number, PropTypes.oneOf(['none', 'empty'])]),
   //   onPress: PropTypes.func,
   static show(fromBounds, items, options = {}) {
+    let { hideWhenUnderViewMove, ...rest } = options;
     return super.show(
-      <this.MenuView fromBounds={fromBounds} items={items} {...options} />
+      <this.MenuView fromBounds={fromBounds} items={items} {...rest} />, { hideWhenUnderViewMove }
     );
   }
 

--- a/components/Overlay/Overlay.js
+++ b/components/Overlay/Overlay.js
@@ -3,7 +3,7 @@
 'use strict';
 
 import React, {Component} from "react";
-import {View} from 'react-native';
+import {View， DeviceEventEmitter} from 'react-native';
 
 import TopView from './TopView';
 import OverlayView from './OverlayView';
@@ -24,7 +24,7 @@ export default class Overlay {
   //   animated: PropTypes.bool,
   //   overlayOpacity: PropTypes.number,
   //   overlayPointerEvents: ViewPropTypes.pointerEvents,
-  static show(overlayView) {
+  static show(overlayView, options = {}) {
     let key;
     let onDisappearCompletedSave = overlayView.props.onDisappearCompleted;
     let element = React.cloneElement(overlayView, {
@@ -34,6 +34,23 @@ export default class Overlay {
       }
     });
     key = TopView.add(element);
+
+    let { hideWhenUnderViewMove } = options;
+    if (hideWhenUnderViewMove) {
+      let moveListener = DeviceEventEmitter.addListener('underViewMove',function(){
+        Overlay.hide(key);
+        moveListener.remove();
+        closeListener.remove();
+      });
+      let closeListener = DeviceEventEmitter.addListener('removeOverlay',function({key: _key} = {}){
+        if (key === _key) {
+          moveListener.remove();
+          closeListener.remove();
+        }
+      });
+
+    }    
+    
     return key;
   }
 

--- a/components/Overlay/OverlayView.js
+++ b/components/Overlay/OverlayView.js
@@ -170,6 +170,7 @@ export default class OverlayView extends Component {
     return (
       <View style={styles.screen} pointerEvents={this.overlayPointerEvents}>
         <Animated.View
+          pointerEvents={this.overlayPointerEvents}
           style={[styles.screen, {backgroundColor: '#000', opacity: this.state.overlayOpacity}]}
           {...this.panResponder.panHandlers}
           />

--- a/components/Overlay/TopView.js
+++ b/components/Overlay/TopView.js
@@ -33,6 +33,11 @@ export default class TopView extends Component {
   static restore(animated, animatesOnly = null) {
     DeviceEventEmitter.emit("restoreRoot", {animated, animatesOnly});
   }
+  
+  static emitUnderViewMove() {
+    const args = [].slice.call(arguments, 0);
+    DeviceEventEmitter.emit("underViewMove", ...args);
+  }
 
   constructor(props) {
     super(props);
@@ -239,7 +244,7 @@ var styles = StyleSheet.create({
 class PureView extends PureComponent {
   render() {
     return (
-      <View style={{flex: 1}}>
+      <View style={{flex: 1}} onTouchMove={TopView.emitUnderViewMove}>
         {this.props.children}
       </View>
     );


### PR DESCRIPTION
Overlay 支持 option 入参 hideWhenUnderViewMove: Bool，
当 hideWhenUnderViewMove 为 true 时监听 Overlay 下方内容的 touchMove 事件移动，移动则关闭 Overlay。